### PR TITLE
DEVTOOLS-47: Improve tool messaging

### DIFF
--- a/containerFactory.js
+++ b/containerFactory.js
@@ -49,6 +49,18 @@ function createContainer() {
       return require('fs');
     });
 
+    container.register('inquirer', function () {
+      var inquirer = require('inquirer');
+      // @HACK: Remove ? prefix from inquirer prompt.
+      _.keys(inquirer.prompt.prompts).forEach(function (prompt) {
+        inquirer.prompt.prompts[prompt].prototype.prefix = function (str) {
+          return str;
+        };
+      });
+
+      return inquirer;
+    });
+
     container.register('osenv', function () {
       return require('osenv');
     });

--- a/tests/unit/commandPrompt.test.js
+++ b/tests/unit/commandPrompt.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+var should = require('should');
+var sinon = require('sinon');
+
+var asserts = require('../support/asserts');
+var containerFactory  = require('../support/testContainerFactory');
+
+var inquirerStub = {};
+
+var message = 'A message';
+
+describe('commandPrompt', function () {
+  beforeEach(function () {
+    inquirerStub.prompt = sinon.stub();
+  });
+
+  describe('getChoice', run(function (commandPrompt) {
+    var nameAttr = 'key';
+    var valueAttr = 'name';
+    var otherAttr = 'otherStuff';
+    var name = 'lala';
+    var value = 'value';
+    var other = 'other';
+
+    var rawOptions = [];
+    rawOptions[0] = {};
+    rawOptions[0][nameAttr] = name;
+    rawOptions[0][valueAttr] = value;
+    rawOptions[0][otherAttr] = other;
+
+    var inquirerOptions = [{
+      name: name,
+      value: value
+    }];
+
+    it('should prompt for a choice', function (done) {
+      inquirerStub.prompt.callsArgWith(1, {
+        answer: 'value'
+      }).returns();
+
+      commandPrompt.getChoice(message, nameAttr, valueAttr, rawOptions)
+        .then(function (choice) {
+          asserts.calledOnceWithExactly(inquirerStub.prompt, [
+            sinon.match({
+              type: 'list',
+              name: 'answer',
+              message: message,
+              choices: inquirerOptions
+            }),
+            sinon.match.func
+          ]);
+
+          choice.should.be.an.Object;
+          should.deepEqual(choice, rawOptions[0]);
+
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+  }));
+
+  describe('getConfirmation', run(function (commandPrompt) {
+    it('should prompt for a confirmation', function (done) {
+      inquirerStub.prompt.callsArgWith(1, {
+        confirm: true
+      }).returns();
+
+      commandPrompt.getConfirmation(message)
+        .then(function (answer) {
+          asserts.calledOnceWithExactly(inquirerStub.prompt, [
+            sinon.match({
+              type: 'confirm',
+              name: 'confirm',
+              message: message,
+              default: true
+            }),
+            sinon.match.func
+          ]);
+
+          answer.should.be.ok;
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+  }));
+});
+
+function run(callback) {
+  return function () {
+    var container = containerFactory.createContainer();
+    container.register('inquirer', inquirerStub);
+    container.resolve(callback);
+  };
+}

--- a/tests/unit/loginPrompt.test.js
+++ b/tests/unit/loginPrompt.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var should = require('should');
+var sinon = require('sinon');
+
+var asserts = require('../support/asserts');
+var containerFactory  = require('../support/testContainerFactory');
+
+var inquirerStub = {};
+var loggerStub = {};
+var messagesStub = {};
+
+var loginMessage = 'message';
+var userCredentials = {
+  name: 'Pepe',
+  password: 'pepe1234'
+};
+
+describe('loginPrompt', function () {
+  beforeEach(function () {
+    inquirerStub.prompt = sinon.stub();
+    loggerStub.info = sinon.stub();
+    messagesStub.loginPromptMessage = sinon.stub().returns(loginMessage);
+  });
+
+  describe('getUserCredentials', run(function (loginPrompt) {
+    it('should prompt for a choice', function (done) {
+      inquirerStub.prompt.callsArgWith(1, userCredentials);
+
+      loginPrompt.getUserCredentials()
+        .then(function (result) {
+          asserts.calledOnceWithExactly(inquirerStub.prompt, [[
+            {
+              type: 'input',
+              name: 'name',
+              message: 'Username: '
+            },
+            {
+              type: 'password',
+              name: 'password',
+              message: 'Password: '
+            }],
+            sinon.match.func
+          ]);
+
+          asserts.calledOnceWithoutParameters([
+            messagesStub.loginPromptMessage]);
+          asserts.calledOnceWithExactly(loggerStub.info, [loginMessage]);
+
+          result.should.be.an.Object;
+          should.deepEqual(result, userCredentials);
+
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+  }));
+});
+
+function run(callback) {
+  return function () {
+    var container = containerFactory.createContainer();
+    container.register('inquirer', inquirerStub);
+    container.register('logger', loggerStub);
+    container.register('messages', messagesStub);
+    container.resolve(callback);
+  };
+}

--- a/utils/commandPrompt.js
+++ b/utils/commandPrompt.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var inquirer = require('inquirer');
 var _ = require('lodash');
 
-module.exports = function () {
+module.exports = function (inquirer) {
   return {
     getChoice: getChoice,
     getConfirmation: getConfirmation

--- a/utils/loginPrompt.js
+++ b/utils/loginPrompt.js
@@ -1,15 +1,13 @@
 'use strict';
 
-var inquirer = require('inquirer');
-
-module.exports = function (logger) {
+module.exports = function (inquirer, logger, messages) {
   return {
     getUserCredentials: getUserCredentials
   };
 
   function getUserCredentials() {
     return new Promise(function (resolve) {
-      logger.info('Enter your APIPlatform username and password');
+      logger.info(messages.loginPromptMessage());
       inquirer.prompt([{
         type: 'input',
         name: 'name',

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -123,6 +123,9 @@ module.exports = function () {
     runPullDescription: function () {
       return 'Run pull after setup (optional)';
     },
+    loginPromptMessage: function () {
+      return 'Enter your APIPlatform username and password';
+    },
     businessGroupPromptMessage: function () {
       return 'Select your business group';
     },
@@ -133,11 +136,11 @@ module.exports = function () {
       return 'Select your API Version';
     },
     storeAuthenticationPromptMessage: function () {
-      return 'Do you want to stay logged in? This will save your access ' +
-          'token in a plain text file.';
+      return 'Do you want to stay logged in? ' +
+        '(More info in http://bit.ly/1BDMOXB)';
     },
     runPullPromptMessage: function () {
-      return 'Do you want to pull your API files now?';
+      return 'Do you want to pull your API definition files now?';
     },
     setupSuccessful: function (workspace) {
       return 'Current setup:\n- Business group: ' + workspace.bizGroup.name +
@@ -180,10 +183,10 @@ module.exports = function () {
       return 'The API is empty';
     },
     downloadingAPI: function () {
-      return 'Downloading the API...';
+      return 'Downloading the API definition files...';
     },
     APIdownloadFinished: function () {
-      return 'API Download finished';
+      return 'API definition files download finished';
     },
     // Errors
     setupNeeded: function () {


### PR DESCRIPTION
- Remove warning from keep user logged in confirmation. Added a link to
  documentation.
- Use "API definition files" instead of "API files" in messages.
- Remove prefix (?) from command prompts
