### PR TITLE
DEVTOOLS-59: Filesystem now ignores files starting with a dot

### DIFF
--- a/lib/repositories/fileSystemRepository.js
+++ b/lib/repositories/fileSystemRepository.js
@@ -61,7 +61,7 @@ module.exports = function (contextHolder, fs, promisify, sha) {
   function getDirectoryFilesPath(directory) {
     return promisify(fs.readdir)(getFileFullPath(directory))
       .then(function (filePaths) {
-        return filePaths.map(function (filePath) {
+        return filePaths.filter(dotFilesFilter).map(function (filePath) {
           var fullLocalFilePath = directory + '/' + filePath;
           return promisify(fs.stat)(getFileFullPath(fullLocalFilePath))
             .then(function (stats) {
@@ -79,5 +79,14 @@ module.exports = function (contextHolder, fs, promisify, sha) {
         return Promise.all(promises);
       })
       .then(_.flatten);
+  }
+
+  /**
+   * Filters files which basenames start with a dot (ex: .git).
+   * @param  {String} filePath The full path of the file to check.
+   * @return {Boolean} True if the filename does not start with a dot.
+   */
+  function dotFilesFilter(filePath) {
+    return path.basename(filePath)[0] !== '.';
   }
 };

--- a/tests/unit/fileSystemRepository.test.js
+++ b/tests/unit/fileSystemRepository.test.js
@@ -112,6 +112,18 @@ describe('fileSystemRepository', function () {
           'folder2'
         ];
         fs[localPath + '/folder1/folder2'] = [];
+        fs[localPath + '/ignoreFilesFolder'] = [
+          '.gitignore',
+          'one.file',
+          '.git',
+          'valid'
+        ];
+        fs[localPath + '/ignoreFilesFolder/valid'] = [
+          'valid.raml'
+        ];
+        fs[localPath + '/ignoreFilesFolder/.git'] = [
+          'gitmetadata'
+        ];
         setFs(fs);
       });
 
@@ -142,6 +154,22 @@ describe('fileSystemRepository', function () {
               done(err);
             });
       });
+
+      it('should return the file tree in a directory ignoring paths starting with a dot',
+        function (done) {
+          fileSystemRepository.getFilesPath('/ignoreFilesFolder')
+            .then(function (filePaths) {
+              should.deepEqual(filePaths, [
+                '/ignoreFilesFolder/one.file',
+                '/ignoreFilesFolder/valid/valid.raml'
+              ]);
+
+              done();
+            })
+            .catch(function (err) {
+              done(err);
+            });
+        });
     }));
 
     describe('with empty workspace', run(function (fileSystemRepository) {


### PR DESCRIPTION
- This is to avoid including VCS metadata files in API definition.
