### PR TITLE
Change superagent-promise intialization as required in V1

### DIFF
--- a/lib/containerFactory.js
+++ b/lib/containerFactory.js
@@ -44,6 +44,7 @@ function createContainer() {
 
   function loadNodeModules() {
     var promisify = require('promisify-node');
+    var superagent = require('superagent');
 
     container.register('fs', function () {
       return require('fs');
@@ -78,11 +79,11 @@ function createContainer() {
     });
 
     container.register('superagent', function () {
-      return require('superagent-promise');
+      return require('superagent-promise')(superagent, require('promise'));
     });
 
     container.register('superagentCallbacks', function () {
-      return require('superagent');
+      return superagent;
     });
   }
 


### PR DESCRIPTION
Superagent-promise version 1 changed the way it's initialized. It now
receives the superagent and promise dependencies when required.
