### PR TITLE
DEVTOOLS-72: Ignore file metadata for .meta files

### DIFF
--- a/lib/repositories/apiPlatformRepository.js
+++ b/lib/repositories/apiPlatformRepository.js
@@ -78,7 +78,7 @@ module.exports = function (contextHolder, errors,
       '/versions/' + apiVersionId +
       '/files'))
       .then(function (response) {
-        return response.body;
+        return response.body.filter(metaFilesFilter);
       })
       .catch(function (err) {
         return Promise.reject(checkUnauthorized(err));
@@ -213,5 +213,9 @@ module.exports = function (contextHolder, errors,
     } else {
       return errorToThrow ? errorToThrow : error;
     }
+  }
+
+  function metaFilesFilter(apiFile) {
+    return path.extname(apiFile.name) !== '.meta';
   }
 };

--- a/tests/unit/apiPlatformRepository.test.js
+++ b/tests/unit/apiPlatformRepository.test.js
@@ -289,9 +289,30 @@ describe('apiPlatformRepository', function () {
 
   describe('getAPIFilesMetadata', run(function (apiPlatformRepository) {
     it('should return all API files metadata', function (done) {
+      var apiFilesMetadata = [
+        {
+          path: '/api.raml',
+          name: 'api.raml',
+          isDirectory: false
+        },
+        {
+          path: '/api.raml.meta',
+          name: 'api.raml.meta',
+          isDirectory: false
+        },
+        {
+          path: '/schema.json',
+          name: 'schema.json',
+          isDirectory: false
+        },
+        {
+          path: '/schema.json.meta',
+          name: 'schema.json.meta',
+          isDirectory: false
+        }
+      ];
       superagentStub.end.returns(Promise.resolve({
-        body: []
-      }));
+        body: apiFilesMetadata}));
 
       apiPlatformRepository.getAPIFilesMetadata(workspace.bizGroup.id,
           workspace.api.id, workspace.apiVersion.id)
@@ -305,6 +326,9 @@ describe('apiPlatformRepository', function () {
           assertReadAPICalls();
 
           allFiles.should.be.an.Array;
+          allFiles.length.should.equal(2);
+          should.deepEqual(allFiles[0], apiFilesMetadata[0]);
+          should.deepEqual(allFiles[1], apiFilesMetadata[2]);
 
           done();
         })


### PR DESCRIPTION
- API Platform metadata API returns .meta files that are API Designer
  specific metadata. Those files are not returned in the export call, so
  we must ignore them also in the metadata call.
