### PR TITLE
DEVTOOLS-75: Add separator in long choices prompt

### DIFF
--- a/lib/utils/commandPrompt.js
+++ b/lib/utils/commandPrompt.js
@@ -16,6 +16,10 @@ module.exports = function (inquirer) {
       };
     });
 
+    if (options.length > 9) {
+      options.push(new inquirer.Separator());
+    }
+
     return new Promise(function (resolve) {
       inquirer.prompt({
         type: 'list',

--- a/tests/unit/commandPrompt.test.js
+++ b/tests/unit/commandPrompt.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var should = require('should');
 var sinon = require('sinon');
 
@@ -11,30 +12,83 @@ var inquirerStub = {};
 var message = 'A message';
 
 describe('commandPrompt', function () {
+  var separator = {separator: true};
+  var nameAttr = 'key';
+  var valueAttr = 'name';
+  var otherAttr = 'otherStuff';
+  var name = 'lala';
+  var value = 'value';
+  var other = 'other';
+
   beforeEach(function () {
     inquirerStub.prompt = sinon.stub();
+    inquirerStub.Separator = sinon.stub().returns(separator);
   });
 
   describe('getChoice', run(function (commandPrompt) {
-    var nameAttr = 'key';
-    var valueAttr = 'name';
-    var otherAttr = 'otherStuff';
-    var name = 'lala';
-    var value = 'value';
-    var other = 'other';
+    it('should prompt for a choice with separator', function (done) {
+      // Options to be passed to commandPrompt.
+      var rawOptions = _.range(10).map(function (i) {
+        var rawOption = {};
+        rawOption[nameAttr] = name + i;
+        rawOption[valueAttr] = value + i;
+        rawOption[otherAttr] = other + i;
 
-    var rawOptions = [];
-    rawOptions[0] = {};
-    rawOptions[0][nameAttr] = name;
-    rawOptions[0][valueAttr] = value;
-    rawOptions[0][otherAttr] = other;
+        return rawOption;
+      });
 
-    var inquirerOptions = [{
-      name: name,
-      value: value
-    }];
+      // Options expected to be received by inquirer.
+      var inquirerOptions = _.map(rawOptions, function (rawOption) {
+        return {
+          name: rawOption[nameAttr],
+          value: rawOption[valueAttr]
+        };
+      });
+      inquirerOptions.push(separator);
 
-    it('should prompt for a choice', function (done) {
+      inquirerStub.prompt.callsArgWith(1, {
+        answer: 'value0'
+      }).returns();
+
+      commandPrompt.getChoice(message, nameAttr, valueAttr, rawOptions)
+        .then(function (choice) {
+          asserts.calledOnceWithExactly(inquirerStub.prompt, [
+            sinon.match({
+              type: 'list',
+              name: 'answer',
+              message: message,
+              choices: inquirerOptions
+            }),
+            sinon.match.func
+          ]);
+
+          inquirerStub.Separator.calledWithNew().should.be.true();
+
+          choice.should.be.an.Object();
+          should.deepEqual(choice, rawOptions[0]);
+
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+
+    it('should prompt for a choice without separator', function (done) {
+      // Options to be passed to commandPrompt.
+      var rawOptions = [{}];
+      rawOptions[0][nameAttr] = name;
+      rawOptions[0][valueAttr] = value;
+      rawOptions[0][otherAttr] = other;
+
+      // Options expected to be received by inquirer.
+      var inquirerOptions = _.map(rawOptions, function (rawOption) {
+        return {
+          name: rawOption[nameAttr],
+          value: rawOption[valueAttr]
+        };
+      });
+
       inquirerStub.prompt.callsArgWith(1, {
         answer: 'value'
       }).returns();
@@ -50,6 +104,8 @@ describe('commandPrompt', function () {
             }),
             sinon.match.func
           ]);
+
+          asserts.notCalled([inquirerStub.Separator]);
 
           choice.should.be.an.Object();
           should.deepEqual(choice, rawOptions[0]);


### PR DESCRIPTION
- When there are more than 9 options to choose from, inquirer shows an
'infinite scroll' list. Added a separator at the end to make it clearer
for the users.

![screen shot 2015-07-02 at 6 51 09 pm](https://cloud.githubusercontent.com/assets/1169708/8488739/61521f44-20eb-11e5-9652-a586f7996d60.png)
