### PR TITLE
DEVTOOLS-76: Store audit information in local workspace

### DIFF
--- a/lib/repositories/apiPlatformRepository.js
+++ b/lib/repositories/apiPlatformRepository.js
@@ -168,6 +168,7 @@ module.exports = function (contextHolder, errors, logger,
       .then(function (response) {
         var createdEntry = response.body;
         return {
+          audit: createdEntry.audit,
           path: newEntry.path,
           id: createdEntry.id
         };
@@ -177,8 +178,8 @@ module.exports = function (contextHolder, errors, logger,
       });
   }
 
-  function updateAPIFile(organizationId, apiId, apiVersionId, updatedFile) {
-    var file = _.pick(updatedFile, [
+  function updateAPIFile(organizationId, apiId, apiVersionId, fileToUpdate) {
+    var file = _.pick(fileToUpdate, [
       'id',
       'name',
       'path',
@@ -193,11 +194,16 @@ module.exports = function (contextHolder, errors, logger,
       '/organizations/' + organizationId +
       '/apis/' + apiId +
       '/versions/' + apiVersionId +
-      '/files/' + updatedFile.id)
+      '/files/' + fileToUpdate.id)
       .set('Content-Type', 'application/json')
       .send(file))
-      .then(function () {
-        return updatedFile.path;
+      .then(function (response) {
+        var updatedFile = response.body;
+        return {
+          audit: updatedFile.audit,
+          path: fileToUpdate.path,
+          id: updatedFile.id
+        };
       })
       .catch(function (err) {
         return Promise.reject(checkUnauthorized(err));

--- a/lib/repositories/csRepository.js
+++ b/lib/repositories/csRepository.js
@@ -53,11 +53,11 @@ module.exports = function (contextHolder, superagent, errors) {
       });
   }
 
-  function checkUnauthorized(error, errorToThrow) {
+  function checkUnauthorized(error) {
     if (error.status === 401) {
       return new errors.BadCredentialsError();
     } else {
-      return errorToThrow ? errorToThrow : error;
+      return error;
     }
   }
 };

--- a/lib/services/apiPlatformService.js
+++ b/lib/services/apiPlatformService.js
@@ -69,10 +69,8 @@ module.exports = function (apiPlatformRepository, contextHolder, decompresser,
         .then(decompressAPI)
         .then(removeCompressedAPI)
         .then(function () {
-          var apiFiles = _.chain(apiFilesMetadata)
-            .filter({isDirectory: false})
-            .pluck('path').value();
-          return getFilesHashes(apiFiles);
+          return getFilesWithHashes(
+            _.filter(apiFilesMetadata, {isDirectory: false}));
         });
 
       function decompressAPI() {
@@ -85,15 +83,9 @@ module.exports = function (apiPlatformRepository, contextHolder, decompresser,
         return fileSystemRepository.removeFile(getCompressedAPIFilePath());
       }
 
-      function getFilesHashes(filePaths) {
-        return Promise.all(filePaths.map(function (filePath) {
-          return fileSystemRepository.getFileHash(filePath)
-            .then(function (hash) {
-              return {
-                path: filePath,
-                hash: hash
-              };
-            });
+      function getFilesWithHashes(files) {
+        return Promise.all(files.map(function (file) {
+          return getFileWithHash(file);
         }));
       }
     }
@@ -116,9 +108,7 @@ module.exports = function (apiPlatformRepository, contextHolder, decompresser,
         return apiPlatformRepository.createAPIFile(organizationId, apiId,
             apiVersionId, newFileData);
       })
-      .then(function (createdFile) {
-        return getFileWithHash(createdFile.path);
-      });
+      .then(getFileWithHash);
   }
 
   function updateAPIFile(organizationId, apiId, apiVersionId, updatedFile) {
@@ -136,13 +126,11 @@ module.exports = function (apiPlatformRepository, contextHolder, decompresser,
         apiVersionId, deletedFile);
   }
 
-  function getFileWithHash(filePath) {
-    return fileSystemRepository.getFileHash(filePath)
+  function getFileWithHash(file) {
+    return fileSystemRepository.getFileHash(file.path)
       .then(function (hash) {
-        return {
-          path: filePath,
-          hash: hash
-        };
+        file.hash = hash;
+        return _.pick(file, ['audit', 'path', 'hash']);
       });
   }
 

--- a/tests/unit/apiPlatformRepository.test.js
+++ b/tests/unit/apiPlatformRepository.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var should = require('should');
 var sinon = require('sinon');
 
@@ -646,9 +647,21 @@ describe('apiPlatformRepository', function () {
       data: 'content'
     };
 
+    var expectedUpdateResponse = {
+      id: file.id,
+      audit: {
+        created: {
+          date: '2015-07-01 20:45:12'
+        },
+        updated: {
+          date: '2015-07-03 20:45:12'
+        }
+      }
+    };
+
     it('should update the specified file', function (done) {
       superagentStub.end.returns(Promise.resolve({
-        body: []
+        body: expectedUpdateResponse
       }));
 
       apiPlatformRepository.updateAPIFile(workspace.bizGroup.id,
@@ -667,8 +680,7 @@ describe('apiPlatformRepository', function () {
             data: file.data
           }));
 
-          updatedFile.should.be.a.String();
-          updatedFile.should.equal(file.path);
+          should.deepEqual(updatedFile, _.set(expectedUpdateResponse, 'path', file.path));
 
           done();
         })

--- a/tests/unit/apiPlatformService.test.js
+++ b/tests/unit/apiPlatformService.test.js
@@ -22,16 +22,36 @@ describe('apiPlatformService', function () {
   var directory = '/Users/test';
   var apiFiles = [
     {
+      audit: {
+        created: {
+          date: '2015-07-03 14:50:00'
+        },
+        updated: {}
+      },
       name: 'api.raml',
       path: '/api.raml',
       isDirectory: false
     },
     {
+      audit: {
+        created: {
+          date: '2015-07-03 14:50:00'
+        },
+        updated: {
+          date: '2015-07-02 13:12:00'
+        }
+      },
       name: 'schema.json',
       path: '/schema.json',
       isDirectory: false
     },
     {
+      audit: {
+        created: {
+          date: '2015-07-03 14:50:00'
+        },
+        updated: {}
+      },
       name: 'temp',
       path: '/temp',
       isDirectory: true
@@ -198,12 +218,18 @@ describe('apiPlatformService', function () {
 
           fileSystemRepositoryStub.getFileHash.calledTwice.should.be.true();
 
-          result.should.be.an.Array();
-          result.length.should.equal(2);
-          result[0].path.should.equal(apiFiles[0].path);
-          result[0].hash.should.equal(fileHash);
-          result[1].path.should.equal(apiFiles[1].path);
-          result[1].hash.should.equal(fileHash);
+          should.deepEqual(result, [
+            {
+              audit: apiFiles[0].audit,
+              path: apiFiles[0].path,
+              hash: fileHash
+            },
+            {
+              audit: apiFiles[1].audit,
+              path: apiFiles[1].path,
+              hash: fileHash
+            }
+          ]);
 
           done();
         })
@@ -295,13 +321,24 @@ describe('apiPlatformService', function () {
       data: 'asdasd'
     };
 
+    var createdFileData = {
+      audit: {
+        created: {
+          date: '2015-07-03 14:50:00'
+        },
+        updated: {}
+      },
+      path: newFile.path,
+      data: newFileData.data
+    };
+
     var fileHash = 'hash';
 
     it('should create API file', function (done) {
       fileSystemRepositoryStub.getFile = sinon.stub().returns(
         Promise.resolve(newFileData));
       apiPlatformRepositoryStub.createAPIFile = sinon.stub().returns(
-        Promise.resolve(newFileData));
+        Promise.resolve(createdFileData));
       fileSystemRepositoryStub.getFileHash = sinon.stub().returns(
         Promise.resolve(fileHash));
 
@@ -324,6 +361,7 @@ describe('apiPlatformService', function () {
               ]);
 
               should.deepEqual(createdFile, {
+                audit: createdFileData.audit,
                 path: newFile.path,
                 hash: fileHash
               });
@@ -347,13 +385,24 @@ describe('apiPlatformService', function () {
       data: 'asdasd'
     };
 
+    var updatedFileData = {
+      audit: {
+        created: {
+          date: '2015-07-03 14:50:00'
+        },
+        updated: {}
+      },
+      path: file.path,
+      data: fileData.data
+    };
+
     var fileHash = 'hash';
 
     it('should update API file', function (done) {
       fileSystemRepositoryStub.getFile = sinon.stub().returns(
         Promise.resolve(fileData));
       apiPlatformRepositoryStub.updateAPIFile = sinon.stub().returns(
-        Promise.resolve(fileData.path));
+        Promise.resolve(updatedFileData));
       fileSystemRepositoryStub.getFileHash = sinon.stub().returns(
         Promise.resolve(fileHash));
 
@@ -376,6 +425,7 @@ describe('apiPlatformService', function () {
               ]);
 
             should.deepEqual(updatedFile, {
+              audit: updatedFileData.audit,
               path: file.path,
               hash: fileHash
             });


### PR DESCRIPTION
- In order to be able to detect changes in remote files, the audit
information will be used when executing a push.