### PR TITLE
DEVTOOLS-78 Cleanup command doesn't require setup anymore

### DIFF
--- a/lib/commands/cleanupCommand.js
+++ b/lib/commands/cleanupCommand.js
@@ -1,20 +1,25 @@
 'use strict';
 
-module.exports = function (cleanupController, logger, messages,
-    validateSetupDoneStrategy) {
+var BPromise = require('bluebird');
+
+module.exports = function (cleanupController, logger, messages) {
   return {
     parseArgs: parseArgs,
-    validateSetup: validateSetupDoneStrategy,
+    validateSetup: validateSetup,
     validateInput: validateInput,
     execute: execute
   };
 
   function parseArgs() {
-    return Promise.resolve();
+    return BPromise.resolve();
   }
 
   function validateInput() {
-    return Promise.resolve();
+    return BPromise.resolve();
+  }
+
+  function validateSetup() {
+    return BPromise.resolve();
   }
 
   function print() {

--- a/tests/unit/cleanupCommand.test.js
+++ b/tests/unit/cleanupCommand.test.js
@@ -9,7 +9,6 @@ var asserts  = require('../support/asserts');
 var cleanupControllerStub = {};
 var loggerStub = {};
 var messagesStub = {};
-var validateSetupDoneStrategyStub = {};
 
 var successfulMessage = 'Success';
 
@@ -18,14 +17,17 @@ describe('cleanupCommand', function () {
     cleanupControllerStub.cleanup = sinon.stub().returns(Promise.resolve());
     messagesStub.cleanup = sinon.stub().returns(successfulMessage);
     loggerStub.info = sinon.stub();
-    validateSetupDoneStrategyStub.validate = sinon.stub();
   });
 
   describe('validateSetup', run(function (cleanupCommand) {
-    it('should be a dependency', function (done) {
-      validateSetupDoneStrategyStub.should.equal(cleanupCommand.validateSetup);
-
-      done();
+    it('should run validation and do nothing', function (done) {
+      cleanupCommand.validateSetup()
+        .then(function () {
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
     });
   }));
 
@@ -77,7 +79,6 @@ function run(callback) {
     container.register('messages', messagesStub);
     container.register('logger', loggerStub);
     container.register('cleanupController', cleanupControllerStub);
-    container.register('validateSetupDoneStrategy', validateSetupDoneStrategyStub);
     container.resolve(callback);
   };
 }


### PR DESCRIPTION
* A cleanup command independent of the setup is far more robust and reliable. It will allow users to reset their folders in any buggy situation, like a user interrupting the tools while it's doing something.