### PR TITLE
Removed promisify-node and replaced it with bluebird

### DIFF
--- a/lib/containerFactory.js
+++ b/lib/containerFactory.js
@@ -43,11 +43,18 @@ function createContainer() {
   }
 
   function loadNodeModules() {
-    var promisify = require('promisify-node');
     var superagent = require('superagent');
+    var fs = require('fs');
+    var BPromise = require('bluebird');
 
-    container.register('fs', function () {
-      return require('fs');
+    container.register('fs', {
+      createWriteStream: fs.createWriteStream,
+      readdir: BPromise.promisify(fs.readdir),
+      readFile: BPromise.promisify(fs.readFile),
+      readFileSync: fs.readFileSync,
+      stat: BPromise.promisify(fs.stat),
+      unlink: BPromise.promisify(fs.unlink),
+      writeFileSync: fs.writeFileSync
     });
 
     container.register('inquirer', function () {
@@ -74,12 +81,11 @@ function createContainer() {
       return process;
     });
 
-    container.register('promisify', function () {
-      return promisify;
-    });
-
     container.register('sha', function () {
-      return promisify('sha');
+      var sha = require('sha');
+      return {
+        get: BPromise.promisify(sha.get)
+      };
     });
 
     container.register('superagent', function () {

--- a/lib/repositories/fileSystemRepository.js
+++ b/lib/repositories/fileSystemRepository.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var _ = require('lodash');
 
-module.exports = function (contextHolder, fs, promisify, sha) {
+module.exports = function (contextHolder, fs, sha) {
   return {
     getDirectoriesPath: getDirectoriesPath,
     getFile: getFile,
@@ -15,7 +15,7 @@ module.exports = function (contextHolder, fs, promisify, sha) {
   };
 
   function getFile(filePath) {
-    return promisify(fs.readFile)(getFileFullPath(filePath), 'utf8')
+    return fs.readFile(getFileFullPath(filePath), 'utf8')
       .then(function (data) {
         return {
           path: filePath,
@@ -61,7 +61,7 @@ module.exports = function (contextHolder, fs, promisify, sha) {
   }
 
   function removeFile(fileLocalPath) {
-    return promisify(fs.unlink)(getFileFullPath(fileLocalPath));
+    return fs.unlink(getFileFullPath(fileLocalPath));
   }
 
   /**
@@ -116,11 +116,11 @@ module.exports = function (contextHolder, fs, promisify, sha) {
    */
   function doWithDirectoryContent(directory,
       doWithFile, doWithDirectory) {
-    return promisify(fs.readdir)(getFileFullPath(directory))
+    return fs.readdir(getFileFullPath(directory))
       .then(function (filePaths) {
         return filePaths.filter(dotFilesFilter).map(function (filePath) {
           var fullLocalFilePath = directory + '/' + filePath;
-          return promisify(fs.stat)(getFileFullPath(fullLocalFilePath))
+          return fs.stat(getFileFullPath(fullLocalFilePath))
             .then(function (stats) {
               if (stats.isDirectory()) {
                 return doWithDirectory(fullLocalFilePath);

--- a/lib/utils/decompresser.js
+++ b/lib/utils/decompresser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var AdmZip = require('adm-zip');
-var promisify = require('promisify-node');
+var BPromise = require('bluebird');
 
 module.exports = function (errors) {
   return {
@@ -16,7 +16,7 @@ module.exports = function (errors) {
       return Promise.reject(new errors.DecompressError(compressedFilePath, e));
     }
 
-    return promisify(zip.extractAllToAsync)(extractDirectoryPath, true)
+    return BPromise.promisify(zip.extractAllToAsync)(extractDirectoryPath, true)
       .catch(function (e) {
         return Promise.reject(
           new errors.DecompressError(compressedFilePath, e));

--- a/lib/utils/workspaceRepository.js
+++ b/lib/utils/workspaceRepository.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var BPromise = require('bluebird');
 var path = require('path');
 
 module.exports = function (errors, fs, osenv, process) {
@@ -27,7 +28,7 @@ module.exports = function (errors, fs, osenv, process) {
       };
     }
 
-    return Promise.resolve(currentWorkspace);
+    return BPromise.resolve(currentWorkspace);
   }
 
   /**
@@ -39,7 +40,7 @@ module.exports = function (errors, fs, osenv, process) {
     var workspaces = read();
     var currentWorkspace = _.find(workspaces, 'directory', process.cwd());
 
-    return Promise.resolve(!!currentWorkspace);
+    return BPromise.resolve(!!currentWorkspace);
   }
 
   /**
@@ -49,7 +50,7 @@ module.exports = function (errors, fs, osenv, process) {
    */
   function update(workspace) {
     if (workspace.directory !== process.cwd()) {
-      return Promise.reject(new errors.WrongDirectoryError());
+      return BPromise.reject(new errors.WrongDirectoryError());
     }
     var workspaces = read();
 
@@ -60,7 +61,7 @@ module.exports = function (errors, fs, osenv, process) {
 
     write(workspaces);
 
-    return Promise.resolve();
+    return BPromise.resolve();
   }
 
   /**
@@ -71,7 +72,7 @@ module.exports = function (errors, fs, osenv, process) {
 
      write(_.reject(workspaces, 'directory', process.cwd()));
 
-     return Promise.resolve();
+     return BPromise.resolve();
    }
 
   /**

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "omelette": "0.3.1",
     "osenv": "0.1.2",
     "promise": "^7.0.3",
-    "promisify-node": "0.1.5",
     "properties": "^1.2.1",
     "sha": "^1.3.0",
     "superagent": "^1.2.0",

--- a/tests/unit/fileSystemRepository.test.js
+++ b/tests/unit/fileSystemRepository.test.js
@@ -15,12 +15,6 @@ var contextStub = {};
 var shaStub = {};
 var fsStub = {};
 
-var promisifyStub = function () {
-  return function (otherFunction) {
-    return otherFunction;
-  };
-};
-
 describe('fileSystemRepository', function () {
   beforeEach(function () {
     contextStub.getDirectoryPath = sinon.stub().returns(localPath);
@@ -341,7 +335,6 @@ function run(callback) {
     container.register('contextHolder', contextHolderStub);
     container.register('sha', shaStub);
     container.register('fs', fsStub);
-    container.register('promisify', promisifyStub);
     container.resolve(callback);
   };
 }


### PR DESCRIPTION
* For fs and sha, register objects that expose only the methods we use. These methods are promisified with bluebird.
 * I don't use promisifyAll because I want to keep the original methods names