### PR TITLE
DEVTOOLS-83: Keep only important fields for workspace directories

### DIFF
--- a/lib/services/apiPlatformService.js
+++ b/lib/services/apiPlatformService.js
@@ -88,7 +88,12 @@ module.exports = function (apiPlatformRepository, BPromise,
           return BPromise.props({
             files: getFilesWithHashes(
               _.filter(apiFilesMetadata, {isDirectory: false})),
-            directories: _.filter(apiFilesMetadata, {isDirectory: true})
+            directories: _.chain(apiFilesMetadata)
+              .filter({isDirectory: true})
+              .map(function (apiFile) {
+                return _.pick(apiFile, 'path', 'audit');
+              })
+              .value()
           });
         });
 

--- a/tests/unit/apiPlatformService.test.js
+++ b/tests/unit/apiPlatformService.test.js
@@ -253,15 +253,8 @@ describe('apiPlatformService', function () {
               hash: fileHash
             }],
             directories: [{
-              audit: {
-                created: {
-                  date: '2015-07-03 14:50:00'
-                },
-                updated: {}
-              },
-              name: 'temp',
-              path: '/temp',
-              isDirectory: true
+              audit: apiFiles[2].audit,
+              path: apiFiles[2].path
             }]
           });
 


### PR DESCRIPTION
- Only path and audit info are stored for directories in workspace.