### PR TITLE
DEVTOOLS-94: Change create flow so authentication fails earlier

### DIFF
--- a/lib/controllers/createController.js
+++ b/lib/controllers/createController.js
@@ -3,63 +3,28 @@
 var path = require('path');
 
 module.exports = function (apiPlatformService, BPromise, fileSystemRepository,
-  localService, logger, messages, userOrganizationService, workspaceRepository) {
+    localService, logger, messages, userOrganizationService, workspaceRepository) {
   return {
     create: create
   };
 
   function create(parametersStrategy) {
-    var createAPIStrategy = {
-      create: function (newApi) {
-        logger.info(messages.creatingAPI());
-        return apiPlatformService.createAPI(
-          newApi.bizGroup,
-          newApi.name,
-          newApi.versionName,
-          newApi.rootRamlPath);
-      },
-      getAPIIdentifier: function (apis, newApi, parametersStrategy) {
-        return parametersStrategy.getAPIName(apis)
-          .tap(function (apiName) {
-            newApi.name = apiName;
-          });
-      }
-    };
-
-    var createAPIVersionStrategy = {
-      create: function (newApi) {
-        logger.info(messages.creatingAPIVersion());
-        return apiPlatformService.createAPIVersion(
-          newApi.bizGroup,
-          newApi.id,
-          newApi.versionName,
-          newApi.rootRamlPath);
-      },
-      getAPIIdentifier: function (apis, newApi, parametersStrategy) {
-        return parametersStrategy.getAPI(apis)
-          .tap(function (api) {
-            newApi.id = api.id;
-          });
-      }
-    };
-
-    return parametersStrategy.getCreateAPIorAPIVersionChoice()
-      .then(function (userWantsToCreateNewAPI) {
-        var creationStrategy = userWantsToCreateNewAPI ?
-          createAPIStrategy :
-          createAPIVersionStrategy;
-        return createAPIorAPIVersion(creationStrategy, parametersStrategy);
-      });
+    return createAPIorAPIVersion(parametersStrategy);
   }
 
-  function createAPIorAPIVersion(creationStrategy, parametersStrategy) {
+  function createAPIorAPIVersion(parametersStrategy) {
     var newApi = {};
     var apis;
+    var creationStrategy;
 
     return userOrganizationService.getBusinessGroups()
       .then(parametersStrategy.getBusinessGroup)
       .tap(function (bizGroup) {
         newApi.bizGroup = bizGroup.id;
+      })
+      .then(parametersStrategy.getCreateAPIorAPIVersionChoice)
+      .tap(function (userWantsToCreateNewAPI) {
+        creationStrategy = createStrategyFactory(userWantsToCreateNewAPI);
       })
       .then(function () {
         return apiPlatformService.getAllAPIs(newApi.bizGroup);
@@ -113,5 +78,43 @@ module.exports = function (apiPlatformService, BPromise, fileSystemRepository,
       var parsedPath = path.parse(filePath);
       return parsedPath.dir === parsedPath.root;
     });
+  }
+
+  function createStrategyFactory(shouldCreateAPI) {
+    var createAPIStrategy = {
+      create: function (newApi) {
+        logger.info(messages.creatingAPI());
+        return apiPlatformService.createAPI(
+          newApi.bizGroup,
+          newApi.name,
+          newApi.versionName,
+          newApi.rootRamlPath);
+      },
+      getAPIIdentifier: function (apis, newApi, parametersStrategy) {
+        return parametersStrategy.getAPIName(apis)
+          .tap(function (apiName) {
+            newApi.name = apiName;
+          });
+      }
+    };
+
+    var createAPIVersionStrategy = {
+      create: function (newApi) {
+        logger.info(messages.creatingAPIVersion());
+        return apiPlatformService.createAPIVersion(
+          newApi.bizGroup,
+          newApi.id,
+          newApi.versionName,
+          newApi.rootRamlPath);
+      },
+      getAPIIdentifier: function (apis, newApi, parametersStrategy) {
+        return parametersStrategy.getAPI(apis)
+          .tap(function (api) {
+            newApi.id = api.id;
+          });
+      }
+    };
+
+    return shouldCreateAPI ? createAPIStrategy : createAPIVersionStrategy;
   }
 };

--- a/tests/unit/createController.test.js
+++ b/tests/unit/createController.test.js
@@ -201,8 +201,9 @@ describe('createController', function () {
 
   function assertCommonCreateStrategy(newApi, apiId) {
     newApi.should.equal(createdApi);
+    asserts.calledOnceWithExactly(
+      parametersStrategyStub.getCreateAPIorAPIVersionChoice, [businessGroup]);
     asserts.calledOnceWithoutParameters([
-      parametersStrategyStub.getCreateAPIorAPIVersionChoice,
       userOrganizationServiceStub.getBusinessGroups,
       workspaceRepositoryStub.get
     ]);


### PR DESCRIPTION
- Change create order so the first action interacts with the Anypoint
Platform. This way, if authentication is expired, the password is asked
before anything else and questions are not repeated.