### PR TITLE
Upgrade dependencies. Remove deprecated rule in jscs

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -89,14 +89,5 @@
 
   "validateLineBreaks": "LF",
   "validateParameterSeparator": ", ",
-  "validateQuoteMarks": "'",
-
-  "validateJSDoc": {
-    "checkAnnotations": "jsdoc3",
-    "checkParamNames": true,
-    "requireParamTypes": true,
-    "checkRedundantParams": true,
-    "requireReturnTypes": true,
-    "checkTypes": "capitalizedNativeCase"
-  }
+  "validateQuoteMarks": "'"
 }

--- a/package.json
+++ b/package.json
@@ -25,30 +25,30 @@
   ],
   "dependencies": {
     "adm-zip": "0.4.7",
-    "bluebird": "^2.9.30",
+    "bluebird": "^2.9.34",
     "colors": "^1.1.2",
     "dependable": "0.2.5",
     "inquirer": "^0.8.5",
-    "lodash": "3.9.3",
-    "minimist": "^1.1.1",
+    "lodash": "3.10.0",
+    "minimist": "^1.1.2",
     "omelette": "0.3.1",
-    "osenv": "0.1.2",
+    "osenv": "0.1.3",
     "properties": "^1.2.1",
     "sha": "^1.3.0",
     "superagent": "^1.2.0",
-    "superagent-promise": "^1.0.0",
-    "winston": "^1.0.0"
+    "superagent-promise": "^1.0.3",
+    "winston": "^1.0.1"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-istanbul": "^0.10.0",
-    "gulp-jscs": "^1.6.0",
-    "gulp-jshint": "^1.11.0",
-    "gulp-mocha": "^2.1.2",
+    "gulp-jscs": "^2.0.0",
+    "gulp-jshint": "^1.11.2",
+    "gulp-mocha": "^2.1.3",
     "jshint-stylish": "^2.0.1",
     "mocha": "^2.2.5",
-    "run-sequence": "^1.1.1",
-    "should": "^7.0.1",
-    "sinon": "^1.15.3"
+    "run-sequence": "^1.1.2",
+    "should": "^7.0.2",
+    "sinon": "^1.15.4"
   }
 }


### PR DESCRIPTION
- Removed validateJSDoc as it was removed in jscs 2.0.0