### PR TITLE
DEVTOOLS-114: Add a polyfill for path.parse

### DIFF
--- a/lib/controllers/createController.js
+++ b/lib/controllers/createController.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var path = require('path');
+path.parse = path.parse || require('path-parse');
 
 module.exports = function (apiPlatformService, BPromise, fileSystemRepository,
     localService, logger, messages, userOrganizationService, workspaceRepository) {

--- a/lib/controllers/pushController.js
+++ b/lib/controllers/pushController.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var path = require('path');
+path.parse = path.parse || require('path-parse');
 
 module.exports = function (apiPlatformService, BPromise,
     errors, forcePushCleanupStrategy, localService, logger, messages,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "gulp"
   },
   "engines": {
-    "node": ">= 0.12"
+    "node": ">= 0.10"
   },
   "author": "MuleSoft",
   "license": "CPAL-1.0",
@@ -30,13 +30,14 @@
     "inquirer": "^0.8.5",
     "lodash": "3.10.0",
     "minimist": "^1.1.2",
-    "unzip": "0.1.11",
     "omelette": "0.3.1",
     "osenv": "0.1.3",
+    "path-parse": "^1.0.5",
     "properties": "^1.2.1",
     "sha": "^1.3.0",
     "superagent": "^1.2.0",
     "superagent-promise": "^1.0.3",
+    "unzip": "0.1.11",
     "winston": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- This makes API-Sync compatible with node 0.10